### PR TITLE
bg-225 defaulting to invisible and setting display to none prerender

### DIFF
--- a/client/src/components/AvatarDOM.scss
+++ b/client/src/components/AvatarDOM.scss
@@ -1,3 +1,7 @@
+.no-show {
+  display: none !important;
+}
+
 .avatar-outer {
     touch-action: none;
     width: 4.5rem;

--- a/client/src/components/AvatarDOM.tsx
+++ b/client/src/components/AvatarDOM.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { Icon } from "atomize";
 import MicOffIcon from "@material-ui/icons/MicOff";
 import cx from "classnames";
 
-import './AvatarDOM.scss';
+import "./AvatarDOM.scss";
 
 function AvatarDOM({
   onPointerDown,
@@ -26,6 +26,7 @@ function AvatarDOM({
   active: boolean;
   mute: boolean;
 }): JSX.Element {
+  const [isRendered, setIsRendered] = useState(false);
   function calculateSpecificStyles() {
     return {
       boxShadow: "0 0 0 " + (1 + multiplier * 10).toString() + "px " + _borderColor,
@@ -36,6 +37,7 @@ function AvatarDOM({
   }
 
   useEffect(() => {
+    setIsRendered(true);
     const avatardom = document.querySelector(".avatar");
     if (avatardom) {
       if (isSelf) {
@@ -56,16 +58,12 @@ function AvatarDOM({
 
   return (
     <div
-      className={cx("avatar", "avatar-outer")}
+      className={cx("avatar", "avatar-outer", { "no-show": !isRendered })}
       onPointerDown={onPointerDown}
       style={calculateSpecificStyles()}
     >
-      <div className="avatar-initial">
-        {initial}
-      </div>
-      <div className="avatar-active">
-        {renderStatusIcon()}
-      </div>
+      <div className="avatar-initial">{initial}</div>
+      <div className="avatar-active">{renderStatusIcon()}</div>
     </div>
   );
 }

--- a/client/src/contexts/UserInfoContext.tsx
+++ b/client/src/contexts/UserInfoContext.tsx
@@ -16,7 +16,7 @@ export type UserInfo = {
 
 export const defaultUserInfo = {
   name: "",
-  avatarColor: { background: "gray", border: "black" },
+  avatarColor: { background: "rgb(0 0 0 / 0%)", border: "rgb(0 0 0 / 0%)" },
   multiplier: 0,
   position: [100, 100] as Position,
   active: true,


### PR DESCRIPTION
## Which Issue was this PR made for?

- Closes #225 

## What is within the scope with this PR

Changing default color to be invisible and setting display to none preload.

## What is NOT in the scope with this PR

### Related Issue

## Other sidenotes that reviewer should be aware of

You can compare the behavior with main by setting a breakpoint at `setIsRendered(true);` (line 40) in `AvatarDOM.tsx` and joining a room.