### PR TITLE
bg-263 Removed profile part of docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,18 +16,18 @@ help:
 
 ## Prepares the dev environment
 dev: 
-	CURRENT_UID=$$(id -u):$$(id -g) docker-compose --profile dev build
+	CURRENT_UID=$$(id -u):$$(id -g) docker-compose build client-dev server-dev
 
 ## Starts the dev environment (Mounts local folder)
 dev-up:
-	CURRENT_UID=$$(id -u):$$(id -g) docker-compose --profile dev up
+	CURRENT_UID=$$(id -u):$$(id -g) docker-compose up client-dev server-dev
 
 ## Starts the prod environment in daemon
 prod-up:
-	docker-compose -f ./docker-compose.yaml -f ./docker-compose.nginx-proxy.yaml --profile prod up -d --build
+	docker-compose -f ./docker-compose.yaml -f ./docker-compose.nginx-proxy.yaml up server-prod client-prod -d --build
 
 beta-up:
-	docker-compose -f ./docker-compose.yaml -f ./docker-compose.nginx-proxy.yaml --profile beta up -d --build
+	docker-compose -f ./docker-compose.yaml -f ./docker-compose.nginx-proxy.yaml up client-beta server-beta -d --build
 
 test:
 	docker-compose run --rm client-test

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,8 +2,6 @@ version: "3.8"
 services:
   server-dev:
     user: ${CURRENT_UID}
-    profiles:
-      - dev
     build:
       context: ./server
       dockerfile: ./Dockerfile
@@ -19,8 +17,6 @@ services:
 
   client-dev:
     user: ${CURRENT_UID}
-    profiles:
-      - dev
     build:
       context: ./client
       dockerfile: ./Dockerfile
@@ -39,16 +35,12 @@ services:
       context: ./client
       dockerfile: ./Dockerfile
       target: test
-    profiles:
-      - test
     command:
       yarn test
 
   ###############################################
   # Prod containers    
   server-prod:
-    profiles:
-      - prod
     build:
       context: ./server
       dockerfile: ./Dockerfile
@@ -59,8 +51,6 @@ services:
       yarn start
 
   client-prod:
-    profiles:
-      - prod
     build:
       context: ./client
       dockerfile: ./Dockerfile
@@ -71,8 +61,6 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
 
   client-beta:
-    profiles:
-      - beta
     build:
       context: ./client
       dockerfile: ./Dockerfile


### PR DESCRIPTION
## Which Issue was this PR made for?

- Closes #263  

## What is within the scope with this PR

- Removing the profile part of docker-compose (I believe this also makes it compatible with docker-compose 1.25
