### PR TITLE
Bg 259 Improve audio visualizer cpu performance

### DIFF
--- a/client/src/classes/AudioVisualizer.ts
+++ b/client/src/classes/AudioVisualizer.ts
@@ -1,7 +1,16 @@
 export class AudioVisualizer {
+  requestId: number;
   onAudioActivity: (gain: number) => void;
   constructor(_onAudioActivity: (gain: number) => void) {
+    this.requestId = null as unknown as number;
     this.onAudioActivity = _onAudioActivity;
+  }
+
+  stop(): void {
+    if (this.requestId) {
+      window.cancelAnimationFrame(this.requestId);
+      this.requestId = null as unknown as number;
+    }
   }
 
   setStream(stream: MediaStream): void {
@@ -29,7 +38,7 @@ export class AudioVisualizer {
           if (average != 0) {
             this.onAudioActivity(average);
           }
-          window.requestAnimationFrame(draw);
+          this.requestId = this.requestId ?? window.requestAnimationFrame(draw);
         };
         draw();
       }

--- a/client/src/classes/AudioVisualizer.ts
+++ b/client/src/classes/AudioVisualizer.ts
@@ -1,13 +1,7 @@
 export class AudioVisualizer {
-  intervalId: number;
   onAudioActivity: (gain: number) => void;
   constructor(_onAudioActivity: (gain: number) => void) {
-    this.intervalId = 0;
     this.onAudioActivity = _onAudioActivity;
-  }
-
-  stop(): void {
-    window.clearInterval(this.intervalId);
   }
 
   setStream(stream: MediaStream): void {
@@ -17,15 +11,12 @@ export class AudioVisualizer {
         const source = context.createMediaStreamSource(stream);
         const analyser = context.createAnalyser();
         analyser.smoothingTimeConstant = 0.3;
-        analyser.fftSize = 1024;
+        analyser.fftSize = 256;
 
         // chain mic -> analyser -> processor -> context
         source.connect(analyser); // feed mic audio into analyser
 
-        if (this.intervalId) {
-          window.clearInterval(this.intervalId);
-          this.onAudioActivity(0);
-        }
+        this.onAudioActivity(0);
         const draw = () => {
           const array = new Uint8Array(analyser.fftSize);
           analyser.getByteFrequencyData(array);
@@ -38,8 +29,9 @@ export class AudioVisualizer {
           if (average != 0) {
             this.onAudioActivity(average);
           }
+          window.requestAnimationFrame(draw);
         };
-        this.intervalId = window.setInterval(draw, 50);
+        draw();
       }
     }
   }
@@ -54,4 +46,3 @@ export const gainToMultiplier = (gain: number): number => {
   }
   return _multiplier;
 };
-

--- a/client/src/classes/AudioVisualizer.ts
+++ b/client/src/classes/AudioVisualizer.ts
@@ -1,16 +1,7 @@
 export class AudioVisualizer {
-  requestId: number;
   onAudioActivity: (gain: number) => void;
   constructor(_onAudioActivity: (gain: number) => void) {
-    this.requestId = null as unknown as number;
     this.onAudioActivity = _onAudioActivity;
-  }
-
-  stop(): void {
-    if (this.requestId) {
-      window.cancelAnimationFrame(this.requestId);
-      this.requestId = null as unknown as number;
-    }
   }
 
   setStream(stream: MediaStream): void {
@@ -38,7 +29,7 @@ export class AudioVisualizer {
           if (average != 0) {
             this.onAudioActivity(average);
           }
-          this.requestId = this.requestId ?? window.requestAnimationFrame(draw);
+          window.requestAnimationFrame(draw);
         };
         draw();
       }

--- a/client/src/classes/PeerProcessor.ts
+++ b/client/src/classes/PeerProcessor.ts
@@ -131,7 +131,6 @@ export class PeerProcessor {
 
   // runs when the data channel closes
   onDataChannelClose(): void {
-    this.visualizer.stop();
   }
 
   onDataChannelMessage(event: MessageEvent): void {

--- a/client/src/classes/PeerProcessor.ts
+++ b/client/src/classes/PeerProcessor.ts
@@ -120,17 +120,13 @@ export class PeerProcessor {
     }
     this.dataChannel = dc;
     this.dataChannel.onopen = this.onDataChannelOpen.bind(this);
-    this.dataChannel.onclose = this.onDataChannelClose.bind(this);
+    // this.dataChannel.onclose = this.onDataChannelClose.bind(this);
     this.dataChannel.onmessage = this.onDataChannelMessage.bind(this);
   }
 
   // runs when the data channel opens
   onDataChannelOpen(): void {
     this.send(this.selfUserInfo);
-  }
-
-  // runs when the data channel closes
-  onDataChannelClose(): void {
   }
 
   onDataChannelMessage(event: MessageEvent): void {

--- a/client/src/components/AvatarDOM.scss
+++ b/client/src/components/AvatarDOM.scss
@@ -4,6 +4,7 @@
     height: 4.5rem;
     border-radius: 100%;
     position: absolute;
+    transition: box-shadow 0.05s;
     display: table;
 
     .avatar-initial {

--- a/client/src/components/AvatarDOM.scss
+++ b/client/src/components/AvatarDOM.scss
@@ -4,7 +4,6 @@
     height: 4.5rem;
     border-radius: 100%;
     position: absolute;
-    transition: box-shadow 0.05s;
     display: table;
 
     .avatar-initial {

--- a/client/src/pages/JoinPage.scss
+++ b/client/src/pages/JoinPage.scss
@@ -1,5 +1,4 @@
 .visualizer {
     height: 10px;
     background: #FDEEC8;
-    transition: width 0.05s;
 }

--- a/client/src/pages/JoinPage.scss
+++ b/client/src/pages/JoinPage.scss
@@ -1,4 +1,5 @@
 .visualizer {
     height: 10px;
     background: #FDEEC8;
+    transition: width 0.05s;
 }

--- a/client/src/pages/JoinPage.tsx
+++ b/client/src/pages/JoinPage.tsx
@@ -32,7 +32,6 @@ const JoinPage = ({
     if (socket) {
       if (name != "") {
         setJoined(true);
-        visualizer.stop();
       } else {
         setShowNotification(true);
       }


### PR DESCRIPTION
## Which Issue was this PR made for?

- Closes #259 

## What is within the scope with this PR

Improve performance by making changes to the audio visualizer.
Mostly by adjusting the [fftSize](https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/fftSize) to 256 and using [requestAnimationFrame](https://developer.mozilla.org/ja/docs/Web/API/Window/requestAnimationFrame) instead of setTimeout

Explanation of requestAnimationFrame being more performant:
https://developer.mozilla.org/en-US/docs/Web/Performance/CSS_JavaScript_animation_performance#requestanimationframe

## What is NOT in the scope with this PR

- #264

### Related Issue

## Other sidenotes that reviewer should be aware of
