### PR TITLE
rf-273 ButtonsComponent should render as desired

### DIFF
--- a/client/src/components/ButtonsBar.tsx
+++ b/client/src/components/ButtonsBar.tsx
@@ -25,7 +25,7 @@ export const ButtonsBar: FunctionComponent<ButtonsBarProps> = (props) => {
     rounded: "circle",
   };
 
-  console.log("RENDER")
+  console.debug("RENDER")
 
   const SettingsButton = () => {
     const { onSettingsClicked } = props;

--- a/client/src/components/ButtonsBar.tsx
+++ b/client/src/components/ButtonsBar.tsx
@@ -25,6 +25,8 @@ export const ButtonsBar: FunctionComponent<ButtonsBarProps> = (props) => {
     rounded: "circle",
   };
 
+  console.log("RENDER")
+
   const SettingsButton = () => {
     const { onSettingsClicked } = props;
 
@@ -104,4 +106,12 @@ ButtonsBar.propTypes = {
   userInfoRef: PropTypes.any,
 };
 
-export default ButtonsBar;
+const areEqual = (prev, next): boolean => {
+  return (prev.userInfoRef.current === next.userInfoRef.current &&
+    prev.onSettingsClicked === next.onSettingsClicked &&
+    prev.onStatusClicked === next.onStatusClicked &&
+    prev.onMuteClicked === next.onMuteClicked &&
+    prev.onLeaveClicked === next.onLeaveClicked)
+}
+
+export default React.memo(ButtonsBar, areEqual);

--- a/client/src/components/ButtonsBar.tsx
+++ b/client/src/components/ButtonsBar.tsx
@@ -14,7 +14,7 @@ type ButtonsBarProps = {
   userInfoRef: any;
 };
 
-export const ButtonsBar: FunctionComponent<ButtonsBarProps> = (props) => {
+const ButtonsBar: FunctionComponent<ButtonsBarProps> = (props) => {
   const defaultButtonStyle = {
     p: "1rem",
     m: "0.3rem",

--- a/client/src/pages/RoomPage.tsx
+++ b/client/src/pages/RoomPage.tsx
@@ -4,7 +4,7 @@ import { useHistory } from "react-router-dom";
 import { DeviceSelector } from "@/components/DeviceSelector";
 import { Div, Notification, Icon, Text } from "atomize";
 import AvatarCanvas from "@/components/AvatarCanvas";
-import { ButtonsBar } from "@/components/ButtonsBar";
+import ButtonsBar from "@/components/ButtonsBar";
 import { Network } from "@/classes/Network";
 import { UserInfo, defaultUserInfo } from "@/contexts/UserInfoContext";
 import { AudioVisualizer, gainToMultiplier } from "@/classes/AudioVisualizer";

--- a/client/src/pages/RoomPage.tsx
+++ b/client/src/pages/RoomPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useContext } from "react";
+import React, { useState, useRef, useEffect, useContext, useCallback } from "react";
 import { SocketContext, DeviceContext, UserInfoContext } from "@/contexts";
 import { useHistory } from "react-router-dom";
 import { DeviceSelector } from "@/components/DeviceSelector";
@@ -53,17 +53,25 @@ function RoomPage({ name }: { name: string }): JSX.Element {
     networkRef.current = _network;
   };
 
-  const toggleMute = () => {
+  const toggleMute = useCallback(() => {
     updateSelfUserInfo({ ...selfUserInfoRef.current, mute: !selfUserInfoRef.current.mute });
-  };
+  }, [selfUserInfoRef.current.mute]);
 
-  const toggleActive = () => {
+  const handleLeaveClicked = useCallback(() => {
+    history.go(0)
+  }, [])
+
+  const handleShowSettingClicked = useCallback(() => {
+    setShowModal(true)
+  }, [])
+
+  const toggleActive = useCallback(() => {
     updateSelfUserInfo({
       ...selfUserInfoRef.current,
       active: !selfUserInfoRef.current.active,
       mute: selfUserInfoRef.current.active,
     });
-  };
+  }, [selfUserInfoRef.current.active]);
 
   // announce and set a new user on join
   const onJoin = (name) => {
@@ -207,11 +215,11 @@ function RoomPage({ name }: { name: string }): JSX.Element {
           setSelfUserInfo={updateSelfUserInfo}
           userInfos={Object.values(userInfos)}
         />
-        <ButtonsBar 
-          onSettingsClicked={() => setShowModal(true)}
-          onStatusClicked={() => toggleActive()}
-          onMuteClicked={() => toggleMute()}
-          onLeaveClicked={() => history.go(0)}
+        <ButtonsBar
+          onSettingsClicked={handleShowSettingClicked}
+          onStatusClicked={toggleActive}
+          onMuteClicked={toggleMute}
+          onLeaveClicked={handleLeaveClicked}
           userInfoRef={selfUserInfoRef}
         />
       </>

--- a/client/src/pages/RoomPage.tsx
+++ b/client/src/pages/RoomPage.tsx
@@ -61,7 +61,7 @@ function RoomPage({ name }: { name: string }): JSX.Element {
     history.go(0)
   }, [])
 
-  const handleShowSettingClicked = useCallback(() => {
+  const handleSettingClicked = useCallback(() => {
     setShowModal(true)
   }, [])
 
@@ -216,7 +216,7 @@ function RoomPage({ name }: { name: string }): JSX.Element {
           userInfos={Object.values(userInfos)}
         />
         <ButtonsBar
-          onSettingsClicked={handleShowSettingClicked}
+          onSettingsClicked={handleSettingClicked}
           onStatusClicked={toggleActive}
           onMuteClicked={toggleMute}
           onLeaveClicked={handleLeaveClicked}


### PR DESCRIPTION
## Which Issue was this PR made for?

- Closes #273

## What is within the scope with this PR

- Prevents unnecessary rendering without losing any functionality

### Related Issue

- #264 

## Other sidenotes that reviewer should be aware of

For some reason, it seems like it is rendering twice each time, but the idea is there.

It is kinda obvious, but when anonyomus function is created, they always allocate new address, so to prevent from re-rendering, it needed a useCallback wrapping outside. `handleSettingClicked` and `handleLeaveClicked`