### PR TITLE
rf-367 Updated node version on github actions

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '18'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Install Playwright
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '18'
       - name: Install modules
         run: yarn install --frozen-lockfile 
       - name: Run ESLint
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '18'
       - name: Install modules
         run: yarn install --frozen-lockfile 
       - name: Run TSLint


### PR DESCRIPTION
## Which Issue was this PR made for?

- Closes #367 

## What is within the scope with this PR

- #368 was missing node version update in github actions, so this is to patch that.
